### PR TITLE
Fixing MSFTserver paper wallet link

### DIFF
--- a/_pages/wallet.md
+++ b/_pages/wallet.md
@@ -45,7 +45,7 @@ permalink: /wallet/
     </div>
     <h2 class="mt-16 mb-8">All Releases</h2>
     <div class="pt-8 mb-8">
-      <a class="inline-block text-lg bg-blue hover:bg-blue-dark rounded p-2 text-white px-8" href="https://github.com/MSFTserver/RavenCoin-Wallet-With-Miners/releases" download><i class="zmdi zmdi-link"></i><span class="inline-block ml-3">View All</span></a>
+      <a class="inline-block text-lg bg-blue hover:bg-blue-dark rounded p-2 text-white px-8" href="http://github.com/MSFTserver/RavenCoin-Wallet-With-Miners/releases" download><i class="zmdi zmdi-link"></i><span class="inline-block ml-3">View All</span></a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
The existing link uses https which the current target site does not support.  Changing to http to resolve the issue.