### PR TITLE
fixing broken email links

### DIFF
--- a/mobilewallet/support/ask-question.html
+++ b/mobilewallet/support/ask-question.html
@@ -51,7 +51,7 @@
                      <h3>Can't find your answer?</h3>
                   </div>
                </div>
-               <p>Send us a message and we'll get back to you as soon as we can.<br /> support@ravenwallet.org <br /> Policy Questions
+               <p>Send us a message and we'll get back to you as soon as we can.<br /> feedback@ravencoin.org <br /> Policy Questions
  
 
                </p>


### PR DESCRIPTION
Surprised there was only one email reference/link. Updated to use feedback@ravencoin.org