### PR TITLE
rename D'CENT wallet

### DIFF
--- a/_data/wallets.yml
+++ b/_data/wallets.yml
@@ -1,4 +1,4 @@
-- name: D'CENT Wallet
+- name: D'CENT
   logo: /assets/img/pages/wallet/dcentwallet.png
   url: https://dcentwallet.com
   asset-support: false


### PR DESCRIPTION
Since the string "Wallet" is duplicated, I removed "Wallet" from name field.