### PR TITLE
Fixed main build. Pools are sorted randomly on each Jekyll build

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -10,27 +10,27 @@
   roadmap:
     - name: Research & Impliment a stable, flexable Operating System across many platforms
       value: complete
-     - name: Created programs to enhance underlining OS for better functioning of Ravencoin Node and IPFS
+    - name: Created programs to enhance underlining OS for better functioning of Ravencoin Node and IPFS
       value: complete
-     - name: Creating Options for more flexiblity of IPFS
+    - name: Creating Options for more flexiblity of IPFS
       value: complete
-     - name: Creating Wiki of all things Ravencoin
+    - name: Creating Wiki of all things Ravencoin
       value: complete
-     - name: Creating web download package for Windows, OSX and Raspberry Pi
+    - name: Creating web download package for Windows, OSX and Raspberry Pi
       value: complete
-     - name: Creating web application for easy (Manual) downloading of NFTs, with Verification & Viewer
+    - name: Creating web application for easy (Manual) downloading of NFTs, with Verification & Viewer
       value: testing
-     - name: Creating application download and install function for Ravencoin projects.
+    - name: Creating application download and install function for Ravencoin projects.
       value: testing
-     - name: Creating a Token function that allows the user to receive continual Tokens based upon the accumulated time RavencoinHelper is maintained.
+    - name: Creating a Token function that allows the user to receive continual Tokens based upon the accumulated time RavencoinHelper is maintained.
       value: testing
-     - name: Creating a website listing and Wiki listing of Ravencoin focused products and services that can be purchased with RavencoinHelper Tokens.
+    - name: Creating a website listing and Wiki listing of Ravencoin focused products and services that can be purchased with RavencoinHelper Tokens.
       value: upcoming
-     - name: Creating Github Repository
+    - name: Creating Github Repository
       value: upcoming
   social:
     - name: RavencoinHelper OS
-     url: https://twitter.com/technobuddha
+      url: https://twitter.com/technobuddha
 
 - name: Electrum Ravencoin
   description: >

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,9 +1,10 @@
 - name: RavencoinHelper OS
-  description: RavencoinHelperOS is an Operating System framework for everything Ravencoin.
+  description: >
+    RavencoinHelperOS is an Operating System framework for everything Ravencoin.
     A foundation of services that are focused upon the Ravencoin Blockchain.
     Its intent is to consolidate everything about Ravencoin,
     and to present it all, to the user for easy access!
-    project_sites:
+  project_sites:
     - name: RavencoinHelper OS
       url: https://ravencoinhelper.com
   roadmap:

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -8,11 +8,11 @@
     - name: RavencoinHelper OS
       url: https://ravencoinhelper.com
   roadmap:
-    - name: Research & Impliment a stable, flexable Operating System across many platforms
+    - name: Research & Implement a stable, flexible Operating System across many platforms
       value: complete
     - name: Created programs to enhance underlining OS for better functioning of Ravencoin Node and IPFS
       value: complete
-    - name: Creating Options for more flexiblity of IPFS
+    - name: Creating Options for more flexibility of IPFS
       value: complete
     - name: Creating Wiki of all things Ravencoin
       value: complete

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,7 +1,7 @@
 - name: RavencoinHelper OS
-  description: >RavencoinHelperOS is an Operating System framework for everything Ravencoin.
+  description: RavencoinHelperOS is an Operating System framework for everything Ravencoin.
     A foundation of services that are focused upon the Ravencoin Blockchain.
-    Its intent is to consolidate everything about Ravencoin, 
+    Its intent is to consolidate everything about Ravencoin,
     and to present it all, to the user for easy access!
     project_sites:
     - name: RavencoinHelper OS
@@ -12,7 +12,7 @@
      - name: Created programs to enhance underlining OS for better functioning of Ravencoin Node and IPFS
       value: complete
      - name: Creating Options for more flexiblity of IPFS
-      value: complete   
+      value: complete
      - name: Creating Wiki of all things Ravencoin
       value: complete
      - name: Creating web download package for Windows, OSX and Raspberry Pi
@@ -30,7 +30,7 @@
   social:
     - name: RavencoinHelper OS
      url: https://twitter.com/technobuddha
-      
+
 - name: Electrum Ravencoin
   description: >
     The Electrum Ravencoin wallet is meant to be a light weight wallet for users who are unable or unwilling
@@ -113,7 +113,7 @@
 - name: RVNFT
   description: >
     RVNFT is a full service NFT Tokenization platform on the Ravencoin Blockchain Network.
-    You can create your own Artwork, Game Reward, Song, Movie, Certificate of Authenticity and much more. 
+    You can create your own Artwork, Game Reward, Song, Movie, Certificate of Authenticity and much more.
     Let RVNFT add it to the Network, so you can focus on what you do best.
   project_sites:
     - name: RVNFT
@@ -133,7 +133,7 @@
       url: https://www.instagram.com/rvnft.art/
     - name: Find RVNFT NFTs on Raven Trader
       url: https://raventrader.net/
-      
+
 - name: SYNTH
   description: >
     SYNTH is a digital guild based on the Main RVN Token which aims to augment the
@@ -142,7 +142,7 @@
     SYNTH has also produced a user friendly front end for current RVN marketplaces & swap
     options, as well as a private high speed IPFS network to host NFTs/Tokens for ourselves &
     partnered NFT creators.
-    
+
   project_sites:
     - name: NiftySynth - Website/Blog for Synth Token
       url: https://www.niftysynth.com/
@@ -162,7 +162,7 @@
     The RavenWallet sponsored by MoonTree is a full featured raven specific mobile wallet.
     From this wallet users can send and recieve RVN, Create distribute and manage Assets,
     as well as trade assets on a distributed exchange in the form of atomic swaps.
-    
+
   project_sites:
     - name: Raven Source Code - a dart library for the projects underlying functionality.
       url: https://github.com/moontreeapp/raven

--- a/_pages/pools.md
+++ b/_pages/pools.md
@@ -30,8 +30,9 @@ permalink: /pools/
 
     <p class="mb-8">Ravencoin (RVN) is supported on:</p>
     <div class="flex flex-wrap">
-      {% assign sorted_pools = site.data.platforms | sort: "name" %}
-      {% for pool in sorted_pools %}
+      {% assign n = site.data.platforms | size %}
+      {% assign random_sorted_pools = site.data.platforms | sample: n %}
+      {% for pool in random_sorted_pools %}
       <div class="mb-2 px-2 sm:w-1/2 md:w-1/3 text-center">
         <div class="bg-grey-lighter max-w-sm rounded overflow-hidden shadow-md hover:by-grey">
           <span class="mb-0"><a class="block p-4" href="{{ pool.url }}" target="_blank">{{ pool.name }}</a></span>

--- a/_pages/pools.md
+++ b/_pages/pools.md
@@ -14,8 +14,9 @@ permalink: /pools/
     <p>To learn how to mine, visit: <a href="https://raven.wiki/wiki/Mining" target="_blank" rel="noopener">https://raven.wiki/wiki/Mining</a></p>
     <p class="mb-8">Ravencoin (RVN) is supported by the following mining pools:</p>
     <div class="flex flex-wrap">
-      {% assign sorted_pools = site.data.pools | sort: "name" %}
-      {% for pool in sorted_pools %}
+      {% assign n = site.data.pools | size %}
+      {% assign random_sorted_pools = site.data.pools | sample: n %}
+      {% for pool in random_sorted_pools %}
       <div class="mb-2 px-2 sm:w-1/2 md:w-1/3 text-center">
         <div class="bg-grey-lighter max-w-sm rounded overflow-hidden shadow-md hover:by-grey">
           <span class="mb-0"><a class="block p-4" href="{{ pool.url }}" target="_blank">{{ pool.name }}</a></span>


### PR DESCRIPTION
- The main build was broken because of bad formatting `projects.yml` – Fixed.
- Added random sorting to the pool list. It will be re-sorted on every Jerkyll build by GitHub. It was done to prevent pools from the beginning of the list to get more clicks (like 2miners which already has 40% of the network)

Demo:
https://allanharris.github.io/pools/
