### PR TITLE
Update block explorer links in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -38,10 +38,7 @@
             <h5 class="text-sm font-semibold uppercase">Developers</h5>
             <ul class="list-reset">
               <li>
-                <a href="https://ravencoin.network/" target="_blank" rel="nofollow">Block Explorer</a>
-              </li>
-              <li>
-                <a href="https://rvn.tokenview.io/" target="_blank" rel="nofollow">Block Explorer 2</a>
+                <a href="https://rvn.tokenview.io/" target="_blank" rel="nofollow">Block Explorer</a>
               </li>
               <li>
                 <a href="https://www.assetsexplorer.com/" target="_blank" rel="nofollow">Asset Explorer 1</a>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -41,6 +41,9 @@
                 <a href="https://rvn.tokenview.io/" target="_blank" rel="nofollow">Block Explorer</a>
               </li>
               <li>
+                <a href="https://rvn.cryptoscope.io/" target="_blank" rel="nofollow">Block Explorer 2</a>
+              </li>
+              <li>
                 <a href="https://www.assetsexplorer.com/" target="_blank" rel="nofollow">Asset Explorer 1</a>
               </li>
               <li>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -38,11 +38,11 @@
             <h5 class="text-sm font-semibold uppercase">Developers</h5>
             <ul class="list-reset">
               <li>
-                <a href="https://rvn.tokenview.io/" target="_blank" rel="nofollow">Block Explorer</a>
+                <a href="https://rvn.cryptoscope.io/" target="_blank" rel="nofollow">Block Explorer</a>
               </li>
               <li>
-                <a href="https://rvn.cryptoscope.io/" target="_blank" rel="nofollow">Block Explorer 2</a>
-              </li>
+                <a href="https://rvn.tokenview.io/" target="_blank" rel="nofollow">Block Explorer 2</a>
+              </li> 
               <li>
                 <a href="https://www.assetsexplorer.com/" target="_blank" rel="nofollow">Asset Explorer 1</a>
               </li>


### PR DESCRIPTION
**Description**
This pull request addresses a broken link in the footer of the ravencoin.org website. 
The link to one of the block explorers is no longer operational, potentially leading users to a dead end.

**Changes Made**

- Removed the link to https://ravencoin.network, as it is no longer in service.
- Retained the existing link to https://rvn.tokenview.io/cn 
- Added a link to https://rvn.cryptoscope.io/, 