### PR TITLE
Add CHISEL project details to projects.yml

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -111,6 +111,21 @@
     - name: Automated create/listing/execution of orders. (Effectively a self-hosted LP)
       value: upcoming
 
+----------------------
+- name: CHISEL
+  description: >
+    CHISEL is a browser-based Ravencoin toolkit for building, signing, and broadcasting 
+    transactions with client-side keys. It integrates with Ravencoin Core via standard 
+    RPC (or lightweight Python wrappers), enabling Web3-style applications while encouraging 
+    users to run their own nodes.
+    
+    project_sites:
+    - name: CHISEL LIVE EXAMPLE
+      url: https://johnrigler.github.io/chisel
+    - name: CHISEL CODEBASE
+      url: https://github.com/johnrigler/chisel
+
+-----------------
 - name: RVNFT
   description: >
     RVNFT is a full service NFT Tokenization platform on the Ravencoin Blockchain Network.


### PR DESCRIPTION
Chisel is built using a web3/vanillaJS approach that means it doesn't need to be hosted on a server in order to handle WIF keys and sign Ravencoin transactions. It uses "elliptic" and other packages. The sample program accepts a private key and then creates, signs and sends a small test transaction that returns all change to the address of origin.

The goal is to position Ravencoin as a Web3 data hub. Transactions can include OP_RETURN data, an IPFS link, or an Asset name. This effort also includes various tools including a special python server proxy that exposes a small subset of server functionality directly to the client. My hope is to encourage others to also run these servers to allow the tool to be more robust and portable. I SUPPORT ONLY PROMOTING TRANSACTIONS THAT INCLUDE A FEE, BUT DO NOT DO THAT TODAY. My site is currently free, but I believe that paying for redundancy would be worth it. 

I am a decentralization fanatic and believe this tool can be using with many currencies, such is Bitcoin (for ordinal creation), BSV (to exploit its enormous OP_RETURN field), and in this case the really leverage the advanced indexing which was created by the Ravencoin team.

This is not intended to be a final customer-facing product, but a small set of powerful infrastructure solutions. 